### PR TITLE
Update type-fu/Diktor.tfl - Semicolon key fixed

### DIFF
--- a/type-fu/Diktor.tfl
+++ b/type-fu/Diktor.tfl
@@ -259,8 +259,8 @@
     },
     "Semicolon": {
       "default": {
-        "base": "ч",
-        "shift": "Ч"
+        "base": "р",
+        "shift": "Р"
       }
     },
     "Backquote": {


### PR DESCRIPTION
На сайте буква Ч дважды появилась, исправлено